### PR TITLE
refactor: extract navigation and sidebar to DOMInterfaceSystem

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -28,9 +28,7 @@ import { SystemPromptBuilder } from "./utils/index.js";
 // Main Application Controller
 class IndustrialPortfolio {
   constructor() {
-    // Theme and font now managed by DOMInterfaceSystem
-    this.currentView = "chat";
-    this.sidebarCollapsed = false;
+    // Theme, font, navigation, and sidebar now managed by DOMInterfaceSystem
     this.initialized = false;
     this.world = new World();
     this.currentChatTarget = null; // Will be set to origin entity by default
@@ -41,9 +39,7 @@ class IndustrialPortfolio {
     console.log("🏭 Initializing...");
 
     try {
-      // Theme and Font systems now handled by DOMInterfaceSystem
-      this.initNavigation();
-      this.initSidebar();
+      // Theme, Font, Navigation, and Sidebar now handled by DOMInterfaceSystem
       this.initChatInterface();
       this.initSessionsList();
       await this.initECS();
@@ -139,44 +135,7 @@ class IndustrialPortfolio {
 
 
 
-  initNavigation() {
-    console.log("🧭 Initializing navigation...");
 
-    const navItems = document.querySelectorAll(".nav-item");
-
-    navItems.forEach((item) => {
-      item.addEventListener("click", (e) => {
-        e.preventDefault();
-        const viewName = item.dataset.view;
-        if (viewName) {
-          this.switchView(viewName);
-        }
-      });
-    });
-
-    console.log("✅ Navigation initialized");
-  }
-
-  initSidebar() {
-    console.log("📱 Initializing sidebar...");
-
-    const sidebarToggle = document.getElementById("sidebar-toggle");
-    const sidebar = document.getElementById("sidebar");
-
-    if (sidebarToggle && sidebar) {
-      sidebarToggle.addEventListener("click", () => {
-        this.toggleSidebar();
-      });
-    }
-
-    // Load saved sidebar state
-    const savedCollapsed = localStorage.getItem("sidebar-collapsed") === "true";
-    if (savedCollapsed) {
-      this.collapseSidebar();
-    }
-
-    console.log("✅ Sidebar initialized");
-  }
 
   initializeDefaultConnections() {
     console.log("🔗 Initializing default connections...");
@@ -1638,56 +1597,7 @@ class IndustrialPortfolio {
 
 
 
-  switchView(viewName) {
-    console.log(`🔄 Switching to ${viewName} view`);
 
-    // Update nav items
-    document.querySelectorAll(".nav-item").forEach((item) => {
-      item.classList.remove("active");
-      if (item.dataset.view === viewName) {
-        item.classList.add("active");
-      }
-    });
-
-    // Update views
-    document.querySelectorAll(".view").forEach((view) => {
-      view.classList.remove("active");
-    });
-
-    const targetView = document.getElementById(`${viewName}-view`);
-    if (targetView) {
-      targetView.classList.add("active");
-      this.currentView = viewName;
-    }
-
-    console.log(`✅ Switched to ${viewName} view`);
-  }
-
-  toggleSidebar() {
-    const sidebar = document.getElementById("sidebar");
-
-    if (this.sidebarCollapsed) {
-      this.expandSidebar();
-    } else {
-      this.collapseSidebar();
-    }
-  }
-
-  collapseSidebar() {
-    const sidebar = document.getElementById("sidebar");
-    sidebar.classList.add("collapsed");
-    this.sidebarCollapsed = true;
-    localStorage.setItem("sidebar-collapsed", "true");
-    console.log("🔼 Sidebar collapsed");
-  }
-
-  expandSidebar() {
-    const sidebar = document.getElementById("sidebar");
-    sidebar.classList.remove("collapsed");
-    this.sidebarCollapsed = false;
-    localStorage.setItem("sidebar-collapsed", "false");
-    console.log("🔽 Sidebar expanded");
-  }
 
   autoResizeTextarea(textarea) {
     textarea.style.height = "auto";

--- a/src/js/systems/DOMInterface/System.js
+++ b/src/js/systems/DOMInterface/System.js
@@ -9,15 +9,19 @@ export class DOMInterfaceSystem extends System {
         super();
         this.requiredComponents = [];
         
-        // Theme and Font state
+        // UI state
         this.currentTheme = "dark";
         this.currentFont = "Inter";
+        this.currentView = "chat";
+        this.sidebarCollapsed = false;
     }
 
     init() {
         console.log("🖥️ Initializing DOMInterface System...");
         this.initThemeSystem();
         this.initFontSystem();
+        this.initNavigationSystem();
+        this.initSidebarSystem();
         console.log("✅ DOMInterface System initialized");
     }
 
@@ -143,6 +147,94 @@ export class DOMInterfaceSystem extends System {
     hideFontDropdown() {
         const fontDropdown = document.getElementById("font-dropdown");
         fontDropdown?.classList.remove("show");
+    }
+
+    initNavigationSystem() {
+        console.log("🧭 Initializing navigation system...");
+
+        const navItems = document.querySelectorAll(".nav-item");
+
+        navItems.forEach((item) => {
+            item.addEventListener("click", (e) => {
+                e.preventDefault();
+                const viewName = item.dataset.view;
+                if (viewName) {
+                    this.switchView(viewName);
+                }
+            });
+        });
+
+        console.log("✅ Navigation system initialized");
+    }
+
+    initSidebarSystem() {
+        console.log("📱 Initializing sidebar system...");
+
+        const sidebarToggle = document.getElementById("sidebar-toggle");
+        const sidebar = document.getElementById("sidebar");
+
+        if (sidebarToggle && sidebar) {
+            sidebarToggle.addEventListener("click", () => {
+                this.toggleSidebar();
+            });
+        }
+
+        // Load saved sidebar state
+        const savedCollapsed = localStorage.getItem("sidebar-collapsed") === "true";
+        if (savedCollapsed) {
+            this.collapseSidebar();
+        }
+
+        console.log("✅ Sidebar system initialized");
+    }
+
+    switchView(viewName) {
+        console.log(`🔄 Switching to ${viewName} view`);
+
+        // Update nav items
+        document.querySelectorAll(".nav-item").forEach((item) => {
+            item.classList.remove("active");
+            if (item.dataset.view === viewName) {
+                item.classList.add("active");
+            }
+        });
+
+        // Update views
+        document.querySelectorAll(".view").forEach((view) => {
+            view.classList.remove("active");
+        });
+
+        const targetView = document.getElementById(`${viewName}-view`);
+        if (targetView) {
+            targetView.classList.add("active");
+            this.currentView = viewName;
+        }
+
+        console.log(`✅ Switched to ${viewName} view`);
+    }
+
+    toggleSidebar() {
+        if (this.sidebarCollapsed) {
+            this.expandSidebar();
+        } else {
+            this.collapseSidebar();
+        }
+    }
+
+    collapseSidebar() {
+        const sidebar = document.getElementById("sidebar");
+        sidebar.classList.add("collapsed");
+        this.sidebarCollapsed = true;
+        localStorage.setItem("sidebar-collapsed", "true");
+        console.log("🔼 Sidebar collapsed");
+    }
+
+    expandSidebar() {
+        const sidebar = document.getElementById("sidebar");
+        sidebar.classList.remove("collapsed");
+        this.sidebarCollapsed = false;
+        localStorage.setItem("sidebar-collapsed", "false");
+        console.log("🔽 Sidebar expanded");
     }
 
     // System update method (required by ECS)


### PR DESCRIPTION
Move navigation and sidebar management from app.js to DOMInterfaceSystem following ECS pattern:
- Extract initNavigation, initSidebar, switchView, toggleSidebar, collapseSidebar, expandSidebar methods
- Maintain all existing functionality while improving code organization
- Reduce app.js size by 94 lines while adhering to ECS architecture

🤖 Generated with [Claude Code](https://claude.ai/code)